### PR TITLE
removes the `:halt-flow` dispatch

### DIFF
--- a/src/day8/re_frame/async_flow_fx.cljs
+++ b/src/day8/re_frame/async_flow_fx.cljs
@@ -4,6 +4,20 @@
     [clojure.set :as set]
     [day8.re-frame.forward-events-fx]))
 
+(defn dissoc-in
+  "Dissociates an entry from a nested associative structure returning a new
+  nested structure. keys is a sequence of keys. Any empty maps that result
+  will not be present in the new structure.
+  The key thing is that 'm' remains identical? to istelf if the path was never present"
+  [m [k & ks :as keys]]
+  (if ks
+    (if-let [nextmap (get m k)]
+      (let [newmap (dissoc-in nextmap ks)]
+        (if (seq newmap)
+          (assoc m k newmap)
+          (dissoc m k)))
+      m)
+    (dissoc m k)))
 
 (defn seen-all-of?
   [required-events seen-events]
@@ -49,11 +63,11 @@
                        :dispatch-n (cond
                                      dispatch-n (if dispatch
                                                   (re-frame/console :error
-                                                                    "async-flow: rule can only specify one of :dispatch and :dispatch-n. Got both: "
-                                                                    rule)
+                                                    "async-flow: rule can only specify one of :dispatch and :dispatch-n. Got both: "
+                                                    rule)
                                                   dispatch-n)
-                                     dispatch   (list dispatch)
-                                     :else      '())}))))
+                                     dispatch (list dispatch)
+                                     :else '())}))))
 
 
 ;; -- Event Handler
@@ -87,12 +101,12 @@
     ;;   (dispatch [:id [:forwarded :event :vector]])
     ;;
     ;; This event handler returns a map of effects - it expects to be registered using
-		;; reg-event-fx
+    ;; reg-event-fx
     ;;
     (fn async-flow-event-hander
-      [{:keys [db]} event-v]
+      [{:keys [db]} [_ event-type :as event-v]]
 
-      (condp = (second event-v)
+      (condp = event-type
         ;; Setup this flow coordinator:
         ;;   1. Establish initial state - :seen-events and ::rules-fired are made empty sets
         ;;   2. dispatch the first event, to kick start flow
@@ -103,14 +117,6 @@
                                  :events      (apply set/union (map :events rules))
                                  :dispatch-to [id]}}
 
-        ;; Teardown this flow coordinator:
-        ;;   1. remove this event handler
-        ;;   2. remove any state stored in app-db
-        ;;   3. deregister the events forwarder
-        :halt-flow {;; :db (dissoc db db-path)  ;; Aggh. I need dissoc-in to make this work.
-                    :forward-events           {:unregister id}
-                    :deregister-event-handler id}
-
         ;; Here we are managing the flow.
         ;; A new event has been forwarded, so work out what should happen:
         ;;  1. does this new event mean we should dispatch another?
@@ -119,15 +125,25 @@
               {:keys [seen-events rules-fired]} (get-state db)
               new-seen-events (conj seen-events forwarded-event-id)
               ready-rules     (startable-rules rules new-seen-events rules-fired)
-							add-halt?       (some :halt? ready-rules)
+              add-halt?       (some :halt? ready-rules)
               ready-rules-ids (->> ready-rules (map :id) set)
               new-rules-fired (set/union rules-fired ready-rules-ids)
-              new-dispatches  (cond-> (mapcat :dispatch-n ready-rules)
-                                add-halt? vec
-                                add-halt? (conj [id :halt-flow]))]
+              new-dispatches  (mapcat :dispatch-n ready-rules)
+              #_(cond-> (mapcat :dispatch-n ready-rules)
+                  add-halt? (dissoc-in db-path))
+              new-db          (set-state db new-seen-events new-rules-fired)]
           (merge
-           {:db (set-state db new-seen-events new-rules-fired)}
-           (when (seq new-dispatches) {:dispatch-n new-dispatches})))))))
+           {:db new-db}
+           (when (seq new-dispatches)
+             {:dispatch-n new-dispatches})
+           (when add-halt?
+             ;; Teardown this flow coordinator:
+             ;;   1. remove this event handler
+             ;;   2. remove any state stored in app-db
+             ;;   3. deregister the events forwarder
+             {:db                       (dissoc-in new-db db-path) ;; Aggh. I need dissoc-in to make this work.
+              :forward-events           {:unregister id}
+              :deregister-event-handler id})))))))
 
 
 (defn- ensure-has-id

--- a/test/day8/re_frame/async_flow_fx_test.cljs
+++ b/test/day8/re_frame/async_flow_fx_test.cljs
@@ -48,7 +48,7 @@
 
 (deftest test-setup
   (let [flow       {:id             :some-id
-										:first-dispatch [:1]
+                    :first-dispatch [:1]
                     :rules          [
                                      {:when :seen? :events :1 :dispatch [:2]}
                                      {:when :seen? :events :3 :halt? true}]}
@@ -66,7 +66,9 @@
               :db-path        [:p]
               :rules [{:id 0 :when :seen? :events :1 :dispatch [:2]}
                       {:id 1 :when :seen? :events :3 :halt? true}
-                      {:id 2 :when :seen-any-of? :events [:4 :5] :dispatch [:6]}]}
+                      {:id 2 :when :seen-any-of? :events [:4 :5] :dispatch [:6]}
+                      {:id 3 :when :seen? :events :6 :halt? true :dispatch [:7]}
+                      ]}
         handler-fn  (core/make-flow-event-handler flow)]
 
     ;; event :no should cause nothing to happen
@@ -89,45 +91,55 @@
              {:db {:p {:seen-events #{}
                        :rules-fired #{}}}}
              [:test-id [:1]])
-           {:db {:p {:seen-events #{:1} :rules-fired #{0}}}
-            :dispatch-n (list [:2])}))
-
-    ;; new event should cause a dispatch
-    (is (= (handler-fn
-             {:db {:p {:seen-events #{:1}
-                       :rules-fired #{0}}}}
-             [:test-id [:3]])
-           {:db {:p {:seen-events #{:1 :3} :rules-fired #{0 1}}}
-            :dispatch-n (list [:test-id :halt-flow])}))
+           {:db         {:p {:seen-events #{:1} :rules-fired #{0}}}
+            :dispatch-n [[:2]]}))
 
     ;; make sure :seen-any-of? works
     (is (= (handler-fn
              {:db {:p {:seen-events #{}
                        :rules-fired #{}}}}
              [:test-id [:4]])
-           {:db {:p {:seen-events #{:4} :rules-fired #{2}}}
-            :dispatch-n (list [:6])}))))
+           {:db         {:p {:seen-events #{:4} :rules-fired #{2}}}
+            :dispatch-n [[:6]]}))))
 
 
 (deftest test-halt1
-  (let [flow {:id :some-id
-							:first-dispatch [:1]
-              :rules []}
+  (let [flow {:first-dispatch [:start]
+              :id             :test-id
+              :db-path        [:p]
+              :rules [{:id 1 :when :seen? :events :3 :halt? true}
+                      {:id 3 :when :seen? :events :6 :halt? true :dispatch [:7]}
+                      ]}
         handler-fn   (core/make-flow-event-handler flow)]
-    (is (= (handler-fn {:db {}} [:dummy-id :halt-flow])
-           { ;; :db {}
-            :deregister-event-handler :some-id
-            :forward-events           {:unregister :some-id}}))))
+    ;; halt event should clean up
+    (is (= (handler-fn
+             {:db {:p {:seen-events #{:1}
+                       :rules-fired #{0}}}}
+             [:test-id [:3]])
+           {:db         {}
+            :forward-events {:unregister :test-id}
+            :deregister-event-handler :test-id}))
+
+    ;; halt event should clean up and dispatch
+    (is (= (handler-fn
+             {:db {:p {:seen-events #{:1}
+                       :rules-fired #{0}}}}
+             [:test-id [:6]])
+           {:db                       {}
+            :forward-events           {:unregister :test-id}
+            :deregister-event-handler :test-id
+            :dispatch-n               [[:7]]}))
+    ))
 
 
-;; Aggh. I don't have dissoc-in available to make this work.
-#_(deftest test-halt2
+(deftest test-halt2
     (let [flow {:id  :blah
                 :db-path [:p]
                 :first-dispatch [:1]
-                :rules []}
+                :rules [{:when :seen? :events :3 :halt? true}]}
           handler-fn   (core/make-flow-event-handler flow)]
-      (is (= (handler-fn {:db {:p {:seen-events #{:33} :rules-fired #{}}}} :halt-flow)
+      (is (= (handler-fn {:db {:p {:seen-events #{:33} :rules-fired #{}}}}
+                         [:blah [:3]])
              {:db                       {}
               :deregister-event-handler :blah
               :forward-events           {:unregister :blah}}))))


### PR DESCRIPTION
This pull request removes the `:halt-flow` dispatch that occurs after the final event defined in the async-flow.

This final dispatch causes problems with async unit-tests as the event will occur after the unit tests have removed the event and watches.