### PR TITLE
Improve event matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,9 @@ A `rule` is a map with the following fields:
 
   - `:when`  one of `:seen?`, `:seen-both?`. `:seen-all-of?`, `:seen-any-of?`
     `:seen?`, `:seen-both?` and `:seen-all-of?` are interchangeable.
-  - `:events` either a single keyword, or a seq of keywords, presumably event ids
+  - `:events` either a single keyword, or a collection of keywords, presumably event ids.
+              a collection can also contain whole event vectors that will be matched,
+              or event predicates that return true or false when passed an event vector.
   - `:dispatch` can be a single vector representing one event to dispatch.
   - `:dispatch-n` to dispatch multiple events, must be a coll where each elem represents one event to dispatch.
   - `:halt?` optional boolean. If true, the flow enters teardown and stops. 

--- a/src/day8/re_frame/async_flow_fx.cljs
+++ b/src/day8/re_frame/async_flow_fx.cljs
@@ -8,7 +8,7 @@
   "Dissociates an entry from a nested associative structure returning a new
   nested structure. keys is a sequence of keys. Any empty maps that result
   will not be present in the new structure.
-  The key thing is that 'm' remains identical? to iself if the path was never present"
+  The key thing is that 'm' remains identical? to itself if the path was never present"
   [m [k & ks :as keys]]
   (if ks
     (if-let [nextmap (get m k)]
@@ -25,7 +25,7 @@
   will either
   - match only the event-keyword if a keyword is supplied
   - match the entire event vector if a collection is supplied
-  - returns a the item itself if a fn is supplied"
+  - returns a callback-pred if it is a fn"
   [callback-pred]
   (when callback-pred
     (cond (fn? callback-pred) callback-pred
@@ -40,16 +40,19 @@
 
 (defn seen-all-of?
   [required-events seen-events]
-  (every?
-    (fn [pred] (some (fn [e] (pred e)) seen-events))
-    (map as-callback-pred required-events)))
+  (let [callback-preds (map as-callback-pred required-events)]
+    (every?
+      (fn [pred] (some pred seen-events))
+      callback-preds)))
 
 
 (defn seen-any-of?
   [required-events seen-events]
-  (some? (some
-           (fn [pred] (some (fn [e] (pred e)) seen-events))
-           (map as-callback-pred required-events))))
+  (let [callback-preds (map as-callback-pred required-events)]
+    (some?
+      (some
+        (fn [pred] (some pred seen-events))
+        callback-preds))))
 
 
 (defn startable-rules

--- a/src/day8/re_frame/async_flow_fx.cljs
+++ b/src/day8/re_frame/async_flow_fx.cljs
@@ -46,17 +46,13 @@
                                   _ (assert (or (= #{:unregister} (-> m keys set))
                                               (= #{:register :events :dispatch-to} (-> m keys set))) (str "re-frame: effects handler for :forward-events given wrong map keys" (-> m keys set)))]
                               (if unregister
-                                (let [f (@id->listen-fn unregister)
-                                      _ (assert (some? f) (str ":forward-events  asked to unregister an unknown id: " unregister))]
-                                  (re-frame/remove-post-event-callback f)
-                                  (swap! id->listen-fn dissoc unregister))
+                                (re-frame/remove-post-event-callback unregister)
                                 (let [events-preds           (map as-callback-pred events)
                                       post-event-callback-fn (fn [event-v _]
                                                                (when (some (fn [pred] (pred event-v))
                                                                        events-preds)
-                                                                 (re-frame/dispatch (conj dispatch-to event-v))))]
-                                  (re-frame/add-post-event-callback post-event-callback-fn)
-                                  (swap! id->listen-fn assoc register post-event-callback-fn)))))]
+                                                                  (re-frame/dispatch (conj dispatch-to event-v))))]
+                                  (re-frame/add-post-event-callback register post-event-callback-fn)))))]
     (fn [val]
       (cond
         (map? val)        (process-one-entry val)
@@ -144,6 +140,7 @@
                       (fn [_] @local-store))
 
         rules       (massage-rules rules)]       ;; all of the events refered to in the rules
+
     ;; Return an event handler which will manage the flow.
     ;; This event handler will receive 3 kinds of events:
     ;;   (dispatch [:id :setup])

--- a/src/day8/re_frame/async_flow_fx.cljs
+++ b/src/day8/re_frame/async_flow_fx.cljs
@@ -2,7 +2,7 @@
   (:require
     [re-frame.core :as re-frame]
     [clojure.set :as set]
-    [day8.re-frame.forward-events-fx]))
+    #_[day8.re-frame.forward-events-fx]))
 
 (defn dissoc-in
   "Dissociates an entry from a nested associative structure returning a new
@@ -37,6 +37,31 @@
                   (ex-info (str (pr-str callback-pred)
                              " isn't an event predicate")
                     {:callback-pred callback-pred})))))
+
+(re-frame/reg-fx
+  :forward-events
+  (let [id->listen-fn     (atom {})
+        process-one-entry (fn [{:as m :keys [unregister register events dispatch-to]}]
+                            (let [_ (assert (map? m) (str "re-frame: effects handler for :forward-events expected a map or a list of maps. Got: " m))
+                                  _ (assert (or (= #{:unregister} (-> m keys set))
+                                              (= #{:register :events :dispatch-to} (-> m keys set))) (str "re-frame: effects handler for :forward-events given wrong map keys" (-> m keys set)))]
+                              (if unregister
+                                (let [f (@id->listen-fn unregister)
+                                      _ (assert (some? f) (str ":forward-events  asked to unregister an unknown id: " unregister))]
+                                  (re-frame/remove-post-event-callback f)
+                                  (swap! id->listen-fn dissoc unregister))
+                                (let [events-preds           (map as-callback-pred events)
+                                      post-event-callback-fn (fn [event-v _]
+                                                               (when (some (fn [pred] (pred event-v))
+                                                                       events-preds)
+                                                                 (re-frame/dispatch (conj dispatch-to event-v))))]
+                                  (re-frame/add-post-event-callback post-event-callback-fn)
+                                  (swap! id->listen-fn assoc register post-event-callback-fn)))))]
+    (fn [val]
+      (cond
+        (map? val)        (process-one-entry val)
+        (sequential? val) (doall (map process-one-entry val))
+        :else (re-frame/console :error  ":forward-events expected a map or a list of maps, but got: " val)))))
 
 (defn seen-all-of?
   [required-events seen-events]
@@ -119,7 +144,6 @@
                       (fn [_] @local-store))
 
         rules       (massage-rules rules)]       ;; all of the events refered to in the rules
-
     ;; Return an event handler which will manage the flow.
     ;; This event handler will receive 3 kinds of events:
     ;;   (dispatch [:id :setup])


### PR DESCRIPTION
Improve event matching by allowing event vectors and predicates in the required-events vector.

In day8 internal code some things that currently can't be handled by an async flow will be possible with these changes.

In this pr I attempt to address some of the comments in https://github.com/Day8/re-frame-async-flow-fx/issues/6 but do it in a different way and do not cover all of the use cases.

In particular, the `event-id->seen-fn` is now handled by providing predicate fn's as used elsewhere in re-frame

