### PR TITLE
Use scope provided

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+##v0.0.7  (2017.07.09)##
+   - remove :halt-flow dispatch
+
 ##v0.0.5  (2016.07.XX)##
     - allow flow handler to be used from non fx handler via flow->handler
     - rules can either use :dispatch for one or :dispatch-n for multiple

--- a/README.md
+++ b/README.md
@@ -356,7 +356,9 @@ A `rule` is a map with the following fields:
 
   - `:when`  one of `:seen?`, `:seen-both?`. `:seen-all-of?`, `:seen-any-of?`
     `:seen?`, `:seen-both?` and `:seen-all-of?` are interchangeable.
-  - `:events` either a single keyword, or a seq of keywords, presumably event ids
+  - `:events` either a single keyword, or a collection of keywords, presumably event ids.
+              a collection can also contain whole event vectors that will be matched,
+              or event predicates that return true or false when passed an event vector.
   - `:dispatch` can be a single vector representing one event to dispatch.
   - `:dispatch-n` to dispatch multiple events, must be a coll where each elem represents one event to dispatch.
   - `:halt?` optional boolean. If true, the flow enters teardown and stops. 

--- a/project.clj
+++ b/project.clj
@@ -2,9 +2,9 @@
   :description  "A re-frame effects handler for coordinating the kind of async control flow which often happens on app startup."
   :url          "https://github.com/Day8/re-frame-async-flow-fx.git"
   :license      {:name "MIT"}
-  :dependencies [[org.clojure/clojure        "1.8.0"]
-                 [org.clojure/clojurescript  "1.9.89"]
-                 [re-frame                   "0.8.0"]
+  :dependencies [[org.clojure/clojure        "1.8.0"  :scope "provided"]
+                 [org.clojure/clojurescript  "1.9.89" :scope "provided"]
+                 [re-frame                   "0.8.0"  :scope "provided"]
                  [day8.re-frame/forward-events-fx "0.0.5"]]
 
   :profiles {:debug {:debug true}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject day8.re-frame/async-flow-fx "0.0.7-SNAPSHOT"
+(defproject day8.re-frame/async-flow-fx "0.0.7"
   :description  "A re-frame effects handler for coordinating the kind of async control flow which often happens on app startup."
   :url          "https://github.com/Day8/re-frame-async-flow-fx.git"
   :license      {:name "MIT"}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject day8.re-frame/async-flow-fx "0.0.8"
+(defproject day8.re-frame/async-flow-fx "0.0.9-SNAPSHOT"
   :description  "A re-frame effects handler for coordinating the kind of async control flow which often happens on app startup."
   :url          "https://github.com/Day8/re-frame-async-flow-fx.git"
   :license      {:name "MIT"}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject day8.re-frame/async-flow-fx "0.0.8-SNAPSHOT"
+(defproject day8.re-frame/async-flow-fx "0.0.8"
   :description  "A re-frame effects handler for coordinating the kind of async control flow which often happens on app startup."
   :url          "https://github.com/Day8/re-frame-async-flow-fx.git"
   :license      {:name "MIT"}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject day8.re-frame/async-flow-fx "0.0.7"
+(defproject day8.re-frame/async-flow-fx "0.0.8-SNAPSHOT"
   :description  "A re-frame effects handler for coordinating the kind of async control flow which often happens on app startup."
   :url          "https://github.com/Day8/re-frame-async-flow-fx.git"
   :license      {:name "MIT"}

--- a/src/day8/re_frame/async_flow_fx.cljs
+++ b/src/day8/re_frame/async_flow_fx.cljs
@@ -2,13 +2,13 @@
   (:require
     [re-frame.core :as re-frame]
     [clojure.set :as set]
-    [day8.re-frame.forward-events-fx]))
+    #_[day8.re-frame.forward-events-fx]))
 
 (defn dissoc-in
   "Dissociates an entry from a nested associative structure returning a new
   nested structure. keys is a sequence of keys. Any empty maps that result
   will not be present in the new structure.
-  The key thing is that 'm' remains identical? to istelf if the path was never present"
+  The key thing is that 'm' remains identical? to itself if the path was never present"
   [m [k & ks :as keys]]
   (if ks
     (if-let [nextmap (get m k)]
@@ -19,14 +19,61 @@
       m)
     (dissoc m k)))
 
+
+(defn as-callback-pred
+  "Looks at the required-events items and returns a predicate which
+  will either
+  - match only the event-keyword if a keyword is supplied
+  - match the entire event vector if a collection is supplied
+  - returns a callback-pred if it is a fn"
+  [callback-pred]
+  (when callback-pred
+    (cond (fn? callback-pred) callback-pred
+          (keyword? callback-pred) (fn [[event-id _]]
+                                     (= callback-pred event-id))
+          (coll? callback-pred) (fn [event-v]
+                                  (= callback-pred event-v))
+          :else (throw
+                  (ex-info (str (pr-str callback-pred)
+                             " isn't an event predicate")
+                    {:callback-pred callback-pred})))))
+
+(re-frame/reg-fx
+  :forward-events
+  (let [id->listen-fn     (atom {})
+        process-one-entry (fn [{:as m :keys [unregister register events dispatch-to]}]
+                            (let [_ (assert (map? m) (str "re-frame: effects handler for :forward-events expected a map or a list of maps. Got: " m))
+                                  _ (assert (or (= #{:unregister} (-> m keys set))
+                                              (= #{:register :events :dispatch-to} (-> m keys set))) (str "re-frame: effects handler for :forward-events given wrong map keys" (-> m keys set)))]
+                              (if unregister
+                                (re-frame/remove-post-event-callback unregister)
+                                (let [events-preds           (map as-callback-pred events)
+                                      post-event-callback-fn (fn [event-v _]
+                                                               (when (some (fn [pred] (pred event-v))
+                                                                       events-preds)
+                                                                  (re-frame/dispatch (conj dispatch-to event-v))))]
+                                  (re-frame/add-post-event-callback register post-event-callback-fn)))))]
+    (fn [val]
+      (cond
+        (map? val)        (process-one-entry val)
+        (sequential? val) (doall (map process-one-entry val))
+        :else (re-frame/console :error  ":forward-events expected a map or a list of maps, but got: " val)))))
+
 (defn seen-all-of?
   [required-events seen-events]
-  (empty? (set/difference required-events seen-events)))
+  (let [callback-preds (map as-callback-pred required-events)]
+    (every?
+      (fn [pred] (some pred seen-events))
+      callback-preds)))
 
 
 (defn seen-any-of?
   [required-events seen-events]
-  (some? (seq (set/intersection seen-events required-events))))
+  (let [callback-preds (map as-callback-pred required-events)]
+    (some?
+      (some
+        (fn [pred] (some pred seen-events))
+        callback-preds))))
 
 
 (defn startable-rules
@@ -121,9 +168,9 @@
         ;; A new event has been forwarded, so work out what should happen:
         ;;  1. does this new event mean we should dispatch another?
         ;;  2. remember this event has happened
-        (let [[_ [forwarded-event-id & args]] event-v
+        (let [[_ forwarded-event] event-v
               {:keys [seen-events rules-fired]} (get-state db)
-              new-seen-events (conj seen-events forwarded-event-id)
+              new-seen-events (conj seen-events forwarded-event)
               ready-rules     (startable-rules rules new-seen-events rules-fired)
               halt?           (some :halt? ready-rules)
               ready-rules-ids (->> ready-rules (map :id) set)

--- a/test/day8/re_frame/async_flow_fx_test.cljs
+++ b/test/day8/re_frame/async_flow_fx_test.cljs
@@ -48,7 +48,7 @@
 
 (deftest test-setup
   (let [flow       {:id             :some-id
-										:first-dispatch [:1]
+                    :first-dispatch [:1]
                     :rules          [
                                      {:when :seen? :events :1 :dispatch [:2]}
                                      {:when :seen? :events :3 :halt? true}]}
@@ -66,7 +66,9 @@
               :db-path        [:p]
               :rules [{:id 0 :when :seen? :events :1 :dispatch [:2]}
                       {:id 1 :when :seen? :events :3 :halt? true}
-                      {:id 2 :when :seen-any-of? :events [:4 :5] :dispatch [:6]}]}
+                      {:id 2 :when :seen-any-of? :events [:4 :5] :dispatch [:6]}
+                      {:id 3 :when :seen? :events :6 :halt? true :dispatch [:7]}
+                      ]}
         handler-fn  (core/make-flow-event-handler flow)]
 
     ;; event :no should cause nothing to happen
@@ -89,45 +91,55 @@
              {:db {:p {:seen-events #{}
                        :rules-fired #{}}}}
              [:test-id [:1]])
-           {:db {:p {:seen-events #{:1} :rules-fired #{0}}}
-            :dispatch-n (list [:2])}))
-
-    ;; new event should cause a dispatch
-    (is (= (handler-fn
-             {:db {:p {:seen-events #{:1}
-                       :rules-fired #{0}}}}
-             [:test-id [:3]])
-           {:db {:p {:seen-events #{:1 :3} :rules-fired #{0 1}}}
-            :dispatch-n (list [:test-id :halt-flow])}))
+           {:db         {:p {:seen-events #{:1} :rules-fired #{0}}}
+            :dispatch-n [[:2]]}))
 
     ;; make sure :seen-any-of? works
     (is (= (handler-fn
              {:db {:p {:seen-events #{}
                        :rules-fired #{}}}}
              [:test-id [:4]])
-           {:db {:p {:seen-events #{:4} :rules-fired #{2}}}
-            :dispatch-n (list [:6])}))))
+           {:db         {:p {:seen-events #{:4} :rules-fired #{2}}}
+            :dispatch-n [[:6]]}))))
 
 
 (deftest test-halt1
-  (let [flow {:id :some-id
-							:first-dispatch [:1]
-              :rules []}
+  (let [flow {:first-dispatch [:start]
+              :id             :test-id
+              :db-path        [:p]
+              :rules [{:id 1 :when :seen? :events :3 :halt? true}
+                      {:id 3 :when :seen? :events :6 :halt? true :dispatch [:7]}
+                      ]}
         handler-fn   (core/make-flow-event-handler flow)]
-    (is (= (handler-fn {:db {}} [:dummy-id :halt-flow])
-           { ;; :db {}
-            :deregister-event-handler :some-id
-            :forward-events           {:unregister :some-id}}))))
+    ;; halt event should clean up
+    (is (= (handler-fn
+             {:db {:p {:seen-events #{:1}
+                       :rules-fired #{0}}}}
+             [:test-id [:3]])
+           {:db         {}
+            :forward-events {:unregister :test-id}
+            :deregister-event-handler :test-id}))
+
+    ;; halt event should clean up and dispatch
+    (is (= (handler-fn
+             {:db {:p {:seen-events #{:1}
+                       :rules-fired #{0}}}}
+             [:test-id [:6]])
+           {:db                       {}
+            :forward-events           {:unregister :test-id}
+            :deregister-event-handler :test-id
+            :dispatch-n               [[:7]]}))
+    ))
 
 
-;; Aggh. I don't have dissoc-in available to make this work.
-#_(deftest test-halt2
+(deftest test-halt2
     (let [flow {:id  :blah
                 :db-path [:p]
                 :first-dispatch [:1]
-                :rules []}
+                :rules [{:when :seen? :events :3 :halt? true}]}
           handler-fn   (core/make-flow-event-handler flow)]
-      (is (= (handler-fn {:db {:p {:seen-events #{:33} :rules-fired #{}}}} :halt-flow)
+      (is (= (handler-fn {:db {:p {:seen-events #{:33} :rules-fired #{}}}}
+                         [:blah [:3]])
              {:db                       {}
               :deregister-event-handler :blah
               :forward-events           {:unregister :blah}}))))


### PR DESCRIPTION
"[provided] indicates you expect the JDK or a container to provide the dependency at runtime"

- https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html

In other words, this dependency won't be included when you include this library, since it
assumed any project that includes this lib will already include Clojure, Clojurescript, and re-frame.

This difference can be detected if a user's project is using the `aot` version of CLJS.

Repro: 

1. Set up a project with the following deps in `project.clj`

```
                 [day8.re-frame/async-flow-fx "0.0.8" ]
                 [org.clojure/clojurescript "1.9.946" :classifier "aot"]
                 [org.clojure/clojure "1.9.0"]
                 [re-frame "0.10.5"]
```

2. run `lein deps :tree`, note the entry for `async-flow-fx`:

```
[day8.re-frame/async-flow-fx "0.0.8"]
   [day8.re-frame/forward-events-fx "0.0.5"]
   [org.clojure/clojurescript "1.9.89"]
     [com.google.javascript/closure-compiler "v20160315"]
```

As you can see, an older version of CLJS is being loaded.

Now try with this patch:

`lein install`

then change `project.clj`

```
                 [day8.re-frame/async-flow-fx "0.0.9-SNAPSHOT"]
                 [org.clojure/clojurescript "1.9.946" :classifier "aot"]
                 [org.clojure/clojure "1.9.0"]
                 [re-frame "0.10.5"]
```

The deps look like:

```
[day8.re-frame/async-flow-fx "0.0.9-SNAPSHOT"]
   [day8.re-frame/forward-events-fx "0.0.5"]
```