### PR TITLE
Use 'provided' scope

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,9 +2,9 @@
   :description  "A re-frame effects handler for coordinating the kind of async control flow which often happens on app startup."
   :url          "https://github.com/Day8/re-frame-async-flow-fx.git"
   :license      {:name "MIT"}
-  :dependencies [[org.clojure/clojure        "1.8.0"]
-                 [org.clojure/clojurescript  "1.9.89"]
-                 [re-frame                   "0.8.0"]
+  :dependencies [[org.clojure/clojure        "1.8.0"  :scope "provided"]
+                 [org.clojure/clojurescript  "1.9.89" :scope "provided"]
+                 [re-frame                   "0.8.0"  :scope "provided"]
                  [day8.re-frame/forward-events-fx "0.0.5"]]
 
   :profiles {:debug {:debug true}


### PR DESCRIPTION
"[provided] indicates you expect the JDK or a container to provide the dependency at runtime"

- https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html

In other words, this dependency won't be included when you include this library, since it
assumed any project that includes this lib will already include Clojure, Clojurescript, and re-frame.

This difference can be detected if a user's project is using the `aot` version of CLJS.

Repro: 

1. Set up a project with the following deps in `project.clj`

```
                 [day8.re-frame/async-flow-fx "0.0.8" ]
                 [org.clojure/clojurescript "1.9.946" :classifier "aot"]
                 [org.clojure/clojure "1.9.0"]
                 [re-frame "0.10.5"]
```

2. run `lein deps :tree`, note the entry for `async-flow-fx`:

```
[day8.re-frame/async-flow-fx "0.0.8"]
   [day8.re-frame/forward-events-fx "0.0.5"]
   [org.clojure/clojurescript "1.9.89"]
     [com.google.javascript/closure-compiler "v20160315"]
```

As you can see, an older version of CLJS is being loaded.

Now try with this patch:

`lein install`

then change `project.clj`

```
                 [day8.re-frame/async-flow-fx "0.0.9-SNAPSHOT"]
                 [org.clojure/clojurescript "1.9.946" :classifier "aot"]
                 [org.clojure/clojure "1.9.0"]
                 [re-frame "0.10.5"]
```

The deps look like:

```
[day8.re-frame/async-flow-fx "0.0.9-SNAPSHOT"]
   [day8.re-frame/forward-events-fx "0.0.5"]
```