### PR TITLE
Flow timeout #2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,9 @@
 ## Unreleased
 
 #### NEW
-   - Add :dispatch-fn to the rule specification. [#20](https://github.com/Day8/re-frame-async-flow-fx/pull/20) see ["Advanced use"](https://github.com/Day8/re-frame-async-flow-fx#advanced-use) in readme
+   - Add  :dispatch-fn to the rule specification. [#20](https://github.com/Day8/re-frame-async-flow-fx/pull/20) see ["Advanced use"](https://github.com/Day8/re-frame-async-flow-fx#advanced-use) in readme
    - Make :first-dispatch optional [#12](https://github.com/Day8/re-frame-async-flow-fx/issues/12)
+   - Add  :timeout optional [#2](https://github.com/Day8/re-frame-async-flow-fx/issues/2)
 
 ## v0.0.7  (2017.07.09)
    - remove :halt-flow dispatch

--- a/README.md
+++ b/README.md
@@ -356,23 +356,28 @@ Further Notes:
 
 ### The Flow Specification
 
-The `:async-flow` data structure has the following fields:
+The flow data structure has the following properties:
 
   - `:id` - optional - an identifier, typically a namespaced keyword. Each flow should have a unique id.
     Must not clash with the identifier for any event handler (because internally
     an event handler is registered using this id).
     If absent, `:async/flow` is used.
-    If this default is used then two flows can't be running at once because they'd be using the same id.
+    
+    **Warning** if the default is used, or you are using more then one flow with the same :id,
+    these flows can't be running at once because they'd be using the same id.
 
-  - `db-path` - optional - the path within `app-db` where the coordination logic should store state. Two pieces
+  - `:db-path` - optional - the path within `app-db` where the coordination logic should store state. Two pieces
      of state are stored:  the set of seen events, and the set of started tasks.
     If absent, then state is not stored in app-db and is instead held in an internal atom.
     We prefer to store state in app-db because we like the philosophy of having all the data in the one place,
     but it is not essential.
-  - `first-dispatch` - optional - the event which initiates the async flow. This is often
+  - `:first-dispatch` - optional - the event which initiates the async flow. This is often
     something like the event which will open a websocket or HTTP GET configuration from the server.
 	If omitted, it is up to you to organise the dispatch of any initial event(s).
-  - `rules` - mandatory - a vector of maps. Each map is a `rule`.
+  - `:timeout` - optional vector of maps each {:ms n :dispatch event-v} where n is number of milliseconds for event-v
+     to fire. It is up to your normal flow *:rules* to decide if to halt and tear down the flow. Further, the timeout 
+    event will fire regardless, and in turn could well be after the flow has completed.
+  - `:rules` - mandatory - a vector of maps. Each map is a `rule`.
 
 A `rule` is a map with the following fields:
 

--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ The flow data structure has the following properties:
     > It is up to the specified timeout handler(s) and your normal flow *:rules* to decide if to halt and tear
     down the flow. Further, the timeout event will fire regardless, and in turn could well be after the flow has completed. 
     If you are using db-path, your timeout handler can query the flow state there, alternatively, the event(s) will have
-    a delay injected as the the last arg which your handler can deref. Possibly stating the obvious, but since this is
+    a delay injected as the last arg which your handler can deref. Possibly stating the obvious, but since this is
     a delay, your handler should deref and decide as soon as possible, after all "time is ticking" uggh. 
     If you handler does decide to halt the flow, it should do so by dispatching one of the existing
     halt rules. See `test-timeout` & `test-timeout-after-halt` in test/day8.re-frame.async-flow-fx-test

--- a/src/day8/re_frame/async_flow_fx.cljs
+++ b/src/day8/re_frame/async_flow_fx.cljs
@@ -180,7 +180,12 @@
                                         :events      (apply set/union (map :events rules))
                                         :dispatch-to [id]}}
                       (when first-dispatch {:dispatch first-dispatch})
-                      (when timeout {:dispatch-later timeout}))
+                      (when timeout
+                        {:dispatch-later (if db-path
+                                           timeout
+                                           (mapv
+                                             (fn [t-m] (update t-m :dispatch #(conj % (delay @local-store))))
+                                             timeout))}))
 
         ;; Here we are managing the flow.
         ;; A new event has been forwarded, so work out what should happen:

--- a/src/day8/re_frame/async_flow_fx.cljs
+++ b/src/day8/re_frame/async_flow_fx.cljs
@@ -161,13 +161,12 @@
         rules       (massage-rules rules)]       ;; all of the events referred to in the rules
 
     ;; Return an event handler which will manage the flow.
-    ;; This event handler will receive 3 kinds of events:
+    ;; This event handler will receive 2 kinds of events:
     ;;   (dispatch [:id :setup])
-    ;;   (dispatch [:id :halt-flow])
     ;;   (dispatch [:id [:forwarded :event :vector]])
     ;;
-    ;; This event handler returns a map of effects - it expects to be registered using
-    ;; reg-event-fx
+    ;; This event handler returns a map of effects to be registered via
+    ;; reg-event-fx see flow->handler
     ;;
     (fn async-flow-event-handler
       [{:keys [db]} [_ event-type :as event-v]]

--- a/test/day8/re_frame/async_flow_fx_test.cljs
+++ b/test/day8/re_frame/async_flow_fx_test.cljs
@@ -148,7 +148,7 @@
         ;        optionally finish flow on an timeout
         ; note3: If flow uses db-path, then the flow state is available there within the db
         ;        passed to the timeout event handler, otherwise a ref to the local flow state
-        ;        is passed as first arg in the form of a delay and can be dereferenced in the
+        ;        is passed as last event arg, via a delay and can be dereferenced in the
         ;        timeout event handler to see if the flow completed or not.
         (is (= (->> @dispatched-events (map first) set) #{::t1 ::t2 ::t3 ::timed-out1}))
         (is (= #{0 1} (get @state-on-timeout :rules-fired)))
@@ -159,7 +159,7 @@
   ;; Since timeout uses :dispatch-later, then the event (s) will always fire,
   ;; even when the flow may have already halted successfully or failed.
   ;; So that the handler can decide what to do at the time of the timeout,
-  ;; it is handed a delay to the flow state (when db-path is not specified) .
+  ;; it is handed a delay to the flow state (when db-path is not specified).
   ;; With this it can decide if the flow has already completed or not and in
   ;; turn choose if it wants to halt the flow or not.
   ;; If the handler chooses to halt, it should do so by dispatching one of


### PR DESCRIPTION
Introduced optional param :timeout which takes n dispatch-later definitions as
```clj
{:timeout [{:ms 3000 :dispatch [::my-timeout-handler]}]}
```
These are mapped to standard :dispatch-later effect but also get an injected delay on the internal flow state (if :db-path is not used). When the timeout handler(s) fire unconditionally, the flow has either completed (successfully or not) or is still waiting for one or more events. The fact that a timeout handler has fired, does not cause the flow to halt and tear down automatically. It is the responsibility of the timeout handler to decide to halt the flow based on the state and dispatch one of the existing halting rules if it so chooses. In the case of a flow which does not specify a `:db-path` the last arg in the timeout event is a delay which the handler can deref to inspect the state at that point. see example in the unit tests `test-timeout` & `test-timeout-after-halt`

This approach was taken to keep the flow handler and state logic simpler in preference to the flow handler maintaining additional state e.g references to js/timeout instances so that they can be cancelled on halt.

Resolves #2 
