### PR TITLE
Remove CHANGES.md mentions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,6 @@ If possible provide:
 * Code that fixes the bug
 * Failing tests which pass with the new changes
 * Improvements to documentation to make it less likely that others will run into issues (if relevant).
-* Add the change to the Unreleased section of [CHANGES.md](CHANGES.md)
 
 ## Pull requests for features
 
@@ -58,4 +57,3 @@ If possible provide:
 * Tests to cover the new feature including all of the code paths
 * Docstrings for functions
 * Documentation examples
-* Add the change to the Unreleased section of [CHANGES.md](CHANGES.md)


### PR DESCRIPTION
The preferred way is releases, according to [this commit](https://github.com/day8/re-frame-async-flow-fx/commit/cc4812d302dabd3ceac39f5acf45a798dd8b98e6#diff-8b1c3fd0d4a6765c16dfd18509182f9d).