### PR TITLE
Fix link to Effects doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ So, it has a similar intent to [mount](https://github.com/tolitius/mount)
 or [component](https://github.com/stuartsierra/component),
 but it dovetails with, and leverages the event driven nature of re-frame's architecture. 
 
-Technically, this library implements an [Effect Handler](https://github.com/day8/re-frame/tree/develop/docs), 
+Technically, this library implements an [Effect Handler](https://github.com/day8/re-frame/blob/master/docs/Effects.md), 
 keyed `:async-flow`. It has a declarative, data oriented design.
 
 #### TOC


### PR DESCRIPTION
The link was deleted in [this commit](https://github.com/day8/re-frame-async-flow-fx/commit/a1824c40de5cafbfcb0f6b1ceb2af9629a551ac0#diff-04c6e90faac2675aa89e2176d2eec7d8) and was pointing to the **Effectful Event Handlers** page.

I've read the older page content and decided to use the link to [Effects.md](https://github.com/day8/re-frame/blob/master/docs/Effects.md) instead, because I thought it's most appropriate page.